### PR TITLE
build: Require newer versions of bundler and rake gems

### DIFF
--- a/qaa-fixtures.gemspec
+++ b/qaa-fixtures.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.2.33"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.3', '>= 3.3.0'
 end


### PR DESCRIPTION
To resolve dependabot alerts